### PR TITLE
22 focustimer session and user status update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# VS Code
+launch.json

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /app/focusbuddy
 
 COPY . .
 RUN pip install --no-cache-dir -r ./requirements.txt
+RUN pip install debugpy
 
 CMD ["python", "./src/main.py"]

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       dockerfile: scripts/Dockerfile
     ports:
       - "8000:8000"
+      - "5678:5678" # Debugger port
     depends_on:
       mongodb:
         condition: service_healthy

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -2,7 +2,7 @@
 # -*- encoding=utf8 -*-
 
 from enum import Enum, IntEnum
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -19,6 +19,24 @@ class BlockListType(IntEnum):
     OTHER: int = 3
     PERMANENT: int = 4
 
+class UserStatus(IntEnum):
+    WORK: int = 0
+    STUDY: int = 1
+    PERSONAL: int = 2
+    OTHER: int = 3
+    IDLE: int = 4
+
+class SessionStatus(IntEnum):
+    UPCOMING: int = 0
+    ONGOING: int = 1
+    PAUSED: int = 2
+    COMPLETED: int = 3
+
+class SessionType(IntEnum):
+    WORK: int = 0
+    STUDY: int = 1
+    PERSONAL: int = 2
+    OTHER: int = 3
 
 class BlockListModel(BaseModel):
     domain: str
@@ -58,6 +76,13 @@ class GetUserAppTokenResponse(BaseModel):
 class GetUserAppTokenRequest(BaseModel):
     token: str
 
+class UpdateUserStatusRequest(BaseModel):
+    user_status: UserStatus
+
+class UpdateUserStatusResponse(BaseModel):
+    status: ResponseStatus = ResponseStatus.SUCCESS
+    user_id: str
+    user_status: UserStatus
 
 class AnalyticsListResponse(BaseModel):
     daily: int = 0
@@ -65,3 +90,17 @@ class AnalyticsListResponse(BaseModel):
     completed_sessions: int = 0
     status: ResponseStatus = ResponseStatus.SUCCESS
 
+class FocusSessionModel(BaseModel):
+    session_status: Optional[SessionStatus] = None
+    start_date: Optional[str] = None
+    start_time: Optional[str] = None
+    duration: Optional[int] = None
+    break_duration: Optional[int] = None
+    session_type: Optional[SessionType] = None
+    remaining_focus_time: Optional[int] = None
+    remaining_break_time: Optional[int] = None
+
+class EditFocusSessionResponse(BaseModel):
+    status: ResponseStatus = ResponseStatus.SUCCESS
+    user_id: str
+    id: str

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -104,3 +104,11 @@ class EditFocusSessionResponse(BaseModel):
     status: ResponseStatus = ResponseStatus.SUCCESS
     user_id: str
     id: str
+
+class GetNextFocusSessionResponse(BaseModel):
+    focus_session: Optional[FocusSessionModel] = None
+    status: ResponseStatus = ResponseStatus.SUCCESS
+
+class GetAllFocusSessionResponse(BaseModel):
+    focus_sessions: list[FocusSessionModel]
+    status: ResponseStatus = ResponseStatus.SUCCESS

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -4,7 +4,7 @@
 from enum import Enum, IntEnum
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 
 
 class ResponseStatus(str, Enum):
@@ -100,15 +100,34 @@ class FocusSessionModel(BaseModel):
     remaining_focus_time: Optional[int] = None
     remaining_break_time: Optional[int] = None
 
+class GetFocusSessionResponse(BaseModel):
+    session_id: Optional[str] = None
+    session_status: Optional[SessionStatus] = None
+    start_date: Optional[str] = None
+    start_time: Optional[str] = None
+    duration: Optional[int] = None
+    break_duration: Optional[int] = None
+    session_type: Optional[SessionType] = None
+    remaining_focus_time: Optional[int] = None
+    remaining_break_time: Optional[int] = None
+
+    @root_validator(pre=True)
+    def set_session_id(cls, values):
+        # If _id exists, map it to session_id
+        if "_id" in values:
+            values["session_id"] = str(values["_id"])  # MongoDB's _id is an ObjectId, so we convert it to string
+            del values["_id"]  # Remove the original _id field
+        return values
+
 class EditFocusSessionResponse(BaseModel):
     status: ResponseStatus = ResponseStatus.SUCCESS
     user_id: str
     id: str
 
 class GetNextFocusSessionResponse(BaseModel):
-    focus_session: Optional[FocusSessionModel] = None
+    focus_session: Optional[GetFocusSessionResponse] = None
     status: ResponseStatus = ResponseStatus.SUCCESS
 
 class GetAllFocusSessionResponse(BaseModel):
-    focus_sessions: list[FocusSessionModel]
+    focus_sessions: list[GetFocusSessionResponse]
     status: ResponseStatus = ResponseStatus.SUCCESS

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -47,6 +47,20 @@ class MongoDB:
                     ("user_id", ASCENDING),
                 ],
             )
+            cls._instance._init_index(
+                "focus_timer",
+                [
+                    ("user_id", ASCENDING),
+                    ("session_status", ASCENDING),
+                    ("start_date", ASCENDING),
+                    ("start_time", ASCENDING),
+                    ("duration", ASCENDING),
+                    ("break_duration", ASCENDING),
+                    ("session_type", ASCENDING),
+                    ("remaining_focus_time", ASCENDING),
+                    ("remaining_break_time", ASCENDING),
+                ],
+            )
         return cls._instance
 
     def _init_index(self, collection_name, index):

--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,6 @@ if __name__ == "__main__":
     
     debugpy.listen(("0.0.0.0", 5678))  # Ensure it's listening
     print("Waiting for debugger to attach...")
-    debugpy.wait_for_client()  # Optional: pauses execution until VS Code attaches
 
     cfg = Config()
     print(f"Starting server at {cfg.app_host}:{cfg.app_port}")

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 # -*- encoding=utf8 -*-
 
 import sys
+import debugpy
 
 sys.path.append(".")
 
@@ -10,6 +11,11 @@ import uvicorn
 from src.config import Config
 
 if __name__ == "__main__":
+    
+    debugpy.listen(("0.0.0.0", 5678))  # Ensure it's listening
+    print("Waiting for debugger to attach...")
+    debugpy.wait_for_client()  # Optional: pauses execution until VS Code attaches
+
     cfg = Config()
     print(f"Starting server at {cfg.app_host}:{cfg.app_port}")
     uvicorn.run("rest:app", host=cfg.app_host, port=cfg.app_port, reload=True)

--- a/src/rest/error.py
+++ b/src/rest/error.py
@@ -26,3 +26,23 @@ INVALID_TOKEN = {
     "code": 10010,
     "message": "Invalid token"
 }
+
+FOCUSSESSION_CONFLICT = {
+    "code": 10011,
+    "message": "Focus session conflict with upcoming sessions"
+}
+
+FOCUSSESSION_NOT_UPDATED = {
+    "code": 10012,
+    "message": "Focus session not updated"
+}
+
+FOCUSSESSION_NOT_FOUND = {
+    "code": 10013,
+    "message": "Focus session not found"
+}
+
+USERSTATUS_NOT_UPDATED = {
+    "code": 10014,
+    "message": "User status not updated"
+}

--- a/src/rest/rest.py
+++ b/src/rest/rest.py
@@ -15,6 +15,10 @@ from src.api import (
     ResponseStatus,
     GetUserAppTokenResponse,
     GetUserAppTokenRequest,
+    UpdateUserStatusRequest,
+    UpdateUserStatusResponse,
+    FocusSessionModel,
+    EditFocusSessionResponse
 )
 from src.config import Config, api_version
 from src.rest.error import (
@@ -23,8 +27,12 @@ from src.rest.error import (
     BLOCKLIST_IS_INVALID,
     BLOCKLIST_NOT_FOUND,
     INVALID_TOKEN,
+    FOCUSSESSION_CONFLICT,
+    FOCUSSESSION_NOT_UPDATED,
+    FOCUSSESSION_NOT_FOUND,
+    USERSTATUS_NOT_UPDATED
 )
-from src.service import AnalyticsListService, BlockListService
+from src.service import AnalyticsListService, BlockListService, FocusTimerService
 from src.service.user import UserService
 
 
@@ -127,6 +135,18 @@ class UserAPI(object):
         self.user_service = UserService(cfg)
         self._register_routes()
 
+    def validate_token(self, token: str) -> (str, bool):
+        """Validate the token."""
+        if token is None:
+            return "", False
+        user = self.user_service.decode_user(token)
+        if user.user_id == "":
+            return "", False
+        now = datetime.datetime.timestamp(datetime.datetime.utcnow())
+        if float(user.exp) < now:
+            return "", False
+        return user.user_id, True
+
     def _register_routes(self):
         """Register API routes."""
         self.router.add_api_route(
@@ -135,6 +155,12 @@ class UserAPI(object):
             methods=["POST"],
             response_model=GetUserAppTokenResponse,
             summary="Get user app token",
+        )
+        self.router.add_api_route(
+            path="/user/status",
+            endpoint=self.update_user_status,
+            methods=["PUT"],
+            summary="Modify user status",
         )
 
     async def get_user_app_token(self, request: GetUserAppTokenRequest):
@@ -147,6 +173,16 @@ class UserAPI(object):
         if user.jwt == "":
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=INVALID_TOKEN)
         return GetUserAppTokenResponse(jwt=user.jwt, email=user.email, picture=user.picture)
+    
+    async def update_user_status(self, request: UpdateUserStatusRequest, x_auth_token: Annotated[str, Header()] = None):
+        """Update user status."""
+        user_id, ok = self.validate_token(x_auth_token)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=INVALID_TOKEN)
+        ok = self.user_service.update_user_status(user_id, request.user_status)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=USERSTATUS_NOT_UPDATED)
+        return UpdateUserStatusResponse(user_id=user_id, user_status=request.user_status, status=ResponseStatus.SUCCESS)
 
 
 class AnalyticsListAPI(object):
@@ -172,11 +208,89 @@ class AnalyticsListAPI(object):
         response = self.analyticslist_service.get_analytics(user_id)
         return response
 
+class FocusTimerAPI(object):
+    """class to encapsulate the focustimer API endpoints."""
+
+    def __init__(self, cfg: Config):
+        self.router = APIRouter()
+        self.timer_service = FocusTimerService(cfg)
+        self.user_service = UserService(cfg)
+        self._register_routes()
+
+    def validate_token(self, token: str) -> (str, bool):
+        """Validate the token."""
+        if token is None:
+            return "", False
+        user = self.user_service.decode_user(token)
+        if user.user_id == "":
+            return "", False
+        now = datetime.datetime.timestamp(datetime.datetime.utcnow())
+        if float(user.exp) < now:
+            return "", False
+        return user.user_id, True
+
+    def _register_routes(self):
+        """Register API routes."""
+        self.router.add_api_route(
+            path="/focustimer",
+            endpoint=self.add_focus_session,
+            methods=["POST"],
+            summary="Add a focus session",
+        )
+        self.router.add_api_route(
+            path="/focustimer/{session_id}",
+            endpoint=self.modify_focus_session,
+            methods=["PUT"],
+            summary="Modify a focus session",
+        )
+        self.router.add_api_route(
+            path="/focustimer/{session_id}",
+            endpoint=self.delete_focus_session,
+            methods=["DELETE"],
+            summary="Delete a focus session",
+        )
+
+    async def add_focus_session(self, request: FocusSessionModel, x_auth_token: Annotated[str, Header()] = None):
+        """Add a focus session."""
+        user_id, ok = self.validate_token(x_auth_token)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=INVALID_TOKEN)
+        session_id, ok = self.timer_service.add_focus_session(user_id, request.session_status, request.start_date, request.start_time, request.duration, request.break_duration, request.session_type, request.remaining_focus_time, request.remaining_break_time)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=FOCUSSESSION_CONFLICT)
+        return EditFocusSessionResponse(user_id=user_id, id=session_id, status=ResponseStatus.SUCCESS)
+    
+    async def modify_focus_session(self, session_id: str, request: FocusSessionModel, x_auth_token: Annotated[str, Header()] = None):
+        """Modify a focus session."""
+        user_id, ok = self.validate_token(x_auth_token)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=INVALID_TOKEN)
+        
+        updates = {k: v for k, v in request.dict().items() if v is not None}
+        if not updates:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=FOCUSSESSION_NOT_UPDATED)
+        
+        ok = self.timer_service.modify_focus_session(user_id, session_id, **updates)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=FOCUSSESSION_NOT_UPDATED)
+        return EditFocusSessionResponse(user_id=user_id, id=session_id, status=ResponseStatus.SUCCESS)
+    
+    async def delete_focus_session(self, session_id: str, x_auth_token: Annotated[str, Header()] = None):
+        """Delete a focus session."""
+        user_id, ok = self.validate_token(x_auth_token)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=INVALID_TOKEN)
+        ok = self.timer_service.delete_focus_session(user_id, session_id)
+        if not ok:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=FOCUSSESSION_NOT_FOUND)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 def create_app(cfg: Config):
     _app = FastAPI()
     blocklist_api = BlockListAPI(cfg)
     analyticslist_api = AnalyticsListAPI(cfg)
+    focustimer_api = FocusTimerAPI(cfg)
+    _app.include_router(focustimer_api.router, prefix=api_version)
     _app.include_router(blocklist_api.router, prefix=api_version)
     user_api = UserAPI(cfg)
     _app.include_router(user_api.router, prefix=api_version)

--- a/src/rest/rest.py
+++ b/src/rest/rest.py
@@ -133,19 +133,6 @@ class BlockListAPI(BaseAPI):
         )
         return url_regex.match(domain)
 
-    # def validate_token(self, token: str) -> (str, bool):
-    #     """Validate the token."""
-    #     if token is None:
-    #         return "", False
-    #     user = self.user_service.decode_user(token)
-    #     if user.user_id == "":
-    #         return "", False
-    #     now = datetime.datetime.timestamp(datetime.datetime.utcnow())
-    #     if float(user.exp) < now:
-    #         return "", False
-    #     return user.user_id, True
-
-
 class UserAPI(BaseAPI):
     """class to encapsulate the user API endpoints."""
 
@@ -190,7 +177,6 @@ class UserAPI(BaseAPI):
         if not ok:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=USERSTATUS_NOT_UPDATED)
         return UpdateUserStatusResponse(user_id=user_id, user_status=request.user_status, status=ResponseStatus.SUCCESS)
-
 
 class AnalyticsListAPI(object):
     """class to encapsulate the analytics API endpoint."""

--- a/src/rest/rest.py
+++ b/src/rest/rest.py
@@ -140,7 +140,6 @@ class UserAPI(BaseAPI):
 
     def __init__(self, cfg: Config):
         super().__init__(cfg)
-        self.router = APIRouter()
         self._register_routes()
 
     def _register_routes(self):

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -3,3 +3,4 @@
 
 from .analytics import AnalyticsListService
 from .blocklist import BlockListService
+from .focustimer import FocusTimerService

--- a/src/service/focustimer.py
+++ b/src/service/focustimer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding=utf8 -*-
 
-from src.api import SessionStatus, SessionType
+from src.api import SessionStatus, SessionType, FocusSessionModel
 from src.config import Config
 from src.db import MongoDB
 from bson import ObjectId 
@@ -56,5 +56,42 @@ class FocusTimerService(object):
         result = collection.delete_one({"user_id": user_id, "_id": ObjectId(session_id)})
         print(result)
         return result.deleted_count > 0
+    
+    def get_next_focus_session(self, user_id: str) -> FocusSessionModel:
+        """Get next upcoming focus session."""
+        collection = self.db.get_collection("focus_timer")
+
+        session = collection.find_one(
+            {"user_id": user_id, "status": 0},  # Filter: Only sessions with status 0
+            sort=[("start_date", 1), ("start_time", 1)]  # Sort: First by date, then by time
+        )
+        
+        return FocusSessionModel(**session) if session else None
+    
+    def get_all_focus_session(self, user_id: str, session_status: int = None) -> list[FocusSessionModel]:
+        """Get focus sessions of specific status, default is fetching all."""
+        collection = self.db.get_collection("focus_timer")
+
+        query = {"user_id": user_id}
+        if session_status is not None:
+            query["session_status"] = session_status
+
+        session_cursor = collection.find(query)
+
+        focus_sessions = [
+            FocusSessionModel(
+                session_status=SessionStatus(doc.get("session_status")),
+                start_date=doc.get("start_date"),
+                start_time=doc.get("start_time"),
+                duration=doc.get("duration"),
+                break_duration=doc.get("break_duration"),
+                session_type=SessionType(doc.get("session_type")),
+                remaining_focus_time=doc.get("remaining_focus_time"),
+                remaining_break_time=doc.get("remaining_break_time"),
+            )
+            for doc in session_cursor
+        ]
+
+        return focus_sessions
 
 

--- a/src/service/focustimer.py
+++ b/src/service/focustimer.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- encoding=utf8 -*-
+
+from src.api import SessionStatus, SessionType
+from src.config import Config
+from src.db import MongoDB
+from bson import ObjectId 
+
+
+class FocusTimerService(object):
+    """class to encapsulate the analytics service."""
+
+    def __init__(self, cfg: Config):
+        self.cfg = cfg
+        self.db = MongoDB().db
+
+    def add_focus_session(self, user_id: str, session_status: SessionStatus, start_date: str, start_time: str, duration: int, break_duration: int, session_type: SessionType, remaining_focus_time: int, remaining_break_time: int) -> (str, bool):
+        """Add focus timer."""
+        """TODO: If session conflict with upcoming sessions, return error."""
+        collection = self.db.get_collection("focus_timer")
+
+        query = {
+            "user_id": user_id,
+            "session_status": session_status,
+            "start_date": start_date,
+            "start_time": start_time,
+            "duration": duration,
+            "break_duration": break_duration,
+            "session_type": session_type,
+            "remaining_focus_time": remaining_focus_time,
+            "remaining_break_time": remaining_break_time
+        }
+        update = {"$setOnInsert": query}
+        result = collection.update_one(query, update, upsert=True)
+        return str(result.upserted_id), True
+    
+    def modify_focus_session(self, user_id: str, session_id: str, **updates) -> bool:
+        """Modify focus timer with optional fields."""
+        collection = self.db.get_collection("focus_timer")
+
+        if not updates:
+            return False
+        
+        if "session_status" in updates:
+            updates["session_status"] = updates["session_status"].value
+        if "session_type" in updates:
+            updates["session_type"] = updates["session_type"].value
+        
+
+        result = collection.update_one({"user_id": user_id, "_id": ObjectId(session_id)}, {"$set": updates})
+        return result.modified_count > 0
+    
+    def delete_focus_session(self, user_id: str, session_id: str) -> bool:
+        """Delete focus timer."""
+        collection = self.db.get_collection("focus_timer")
+        result = collection.delete_one({"user_id": user_id, "_id": ObjectId(session_id)})
+        print(result)
+        return result.deleted_count > 0
+
+

--- a/src/service/focustimer.py
+++ b/src/service/focustimer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding=utf8 -*-
 
-from src.api import SessionStatus, SessionType, FocusSessionModel
+from src.api import SessionStatus, SessionType, GetFocusSessionResponse
 from src.config import Config
 from src.db import MongoDB
 from bson import ObjectId 
@@ -54,10 +54,9 @@ class FocusTimerService(object):
         """Delete focus timer."""
         collection = self.db.get_collection("focus_timer")
         result = collection.delete_one({"user_id": user_id, "_id": ObjectId(session_id)})
-        print(result)
         return result.deleted_count > 0
     
-    def get_next_focus_session(self, user_id: str) -> FocusSessionModel:
+    def get_next_focus_session(self, user_id: str) -> GetFocusSessionResponse:
         """Get next upcoming focus session."""
         collection = self.db.get_collection("focus_timer")
 
@@ -66,9 +65,9 @@ class FocusTimerService(object):
             sort=[("start_date", 1), ("start_time", 1)]  # Sort: First by date, then by time
         )
         
-        return FocusSessionModel(**session) if session else None
+        return GetFocusSessionResponse(**session) if session else None
     
-    def get_all_focus_session(self, user_id: str, session_status: int = None) -> list[FocusSessionModel]:
+    def get_all_focus_session(self, user_id: str, session_status: int = None) -> list[GetFocusSessionResponse]:
         """Get focus sessions of specific status, default is fetching all."""
         collection = self.db.get_collection("focus_timer")
 
@@ -79,7 +78,8 @@ class FocusTimerService(object):
         session_cursor = collection.find(query)
 
         focus_sessions = [
-            FocusSessionModel(
+            GetFocusSessionResponse(
+                session_id = str(doc["_id"]),
                 session_status=SessionStatus(doc.get("session_status")),
                 start_date=doc.get("start_date"),
                 start_time=doc.get("start_time"),

--- a/tests/test_focustimer.py
+++ b/tests/test_focustimer.py
@@ -93,6 +93,42 @@ class TestFocusTimer(unittest.TestCase):
         assert response[0] != ""  # Should return a valid ObjectId
         assert response[1] is True  # Should return True
 
+    def test_add_conflic_session(self):
+        collection = self.db.get_collection("focus_timer")
+        collection.delete_many({})
+        # Insert a test entry
+        test_entry = {
+            "user_id": self.user_id,
+            "session_status": SessionStatus.UPCOMING,
+            "start_date": "02/22/2025",
+            "start_time": "23:16:15",
+            "duration": 1,
+            "break_duration": 1,
+            "session_type": SessionType.WORK,
+            "remaining_focus_time": 60,
+            "remaining_break_time": 60
+        }
+        response = self.app.post("/api/v1/focustimer", json=test_entry, headers={"x-auth-token": self.jwt_token})
+
+        # logging.debug(f"Document count after insertion: {collection.count_documents({})}")
+        # logging.debug(f"Response in adding: {response.json()}")
+        assert response.status_code == 200
+
+        test_entry2 = {
+            "user_id": self.user_id,
+            "session_status": SessionStatus.UPCOMING,
+            "start_date": "02/22/2025",
+            "start_time": "23:15:15",
+            "duration": 1,
+            "break_duration": 1,
+            "session_type": SessionType.WORK,
+            "remaining_focus_time": 60,
+            "remaining_break_time": 60
+        }
+        response = self.app.post("/api/v1/focustimer", json=test_entry2, headers={"x-auth-token": self.jwt_token})
+        # logging.debug(f"Document count after insertion: {collection.count_documents({})}")
+        assert response.status_code == 409
+        
 
     """Test update_focustimer."""
 

--- a/tests/test_focustimer.py
+++ b/tests/test_focustimer.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- encoding=utf8 -*-
+import unittest
+from bson import ObjectId
+
+from src.config import Config
+from src.service.user import UserService
+from tests.test_utils import get_test_app
+from src.api import ResponseStatus, SessionStatus, SessionType
+from src.db import MongoDB  # Import the MongoDB singleton
+from src.service.focustimer import FocusTimerService
+
+# import logging
+
+# logging.basicConfig(level=logging.DEBUG)
+
+class TestFocusTimer(unittest.TestCase):
+    app = get_test_app()
+    db = MongoDB().db
+    user_service = UserService(cfg=Config())
+    user_id = "focusbuddy_test"
+    jwt_token = user_service._generate_jwt("focusbuddy_test", "focusbuddy.test@gmail.com")
+
+    def test_get_all_focustimer(self):
+        response = self.app.get("/api/v1/focustimer", headers={"x-auth-token": self.jwt_token})
+        assert response.status_code == 200
+        assert response.json() == {
+            "focus_sessions": [],
+            "status": ResponseStatus.SUCCESS,
+        }
+
+    def test_get_all_focustimer_non_empty(self):
+        collection = self.db.get_collection("focus_timer")
+        collection.delete_many({})
+        # Insert a test entry
+        test_entry = {
+            "user_id": self.user_id,
+            "session_status": SessionStatus.UPCOMING,
+            "start_date": "02/22/2025",
+            "start_time": "23:16:15",
+            "duration": 1,
+            "break_duration": 1,
+            "session_type": SessionType.WORK,
+            "remaining_focus_time": 60,
+            "remaining_break_time": 60
+        }
+        inserted_id = collection.insert_one(test_entry).inserted_id
+        response = self.app.get("/api/v1/focustimer", headers={"x-auth-token": self.jwt_token})
+        assert response.status_code == 200
+        # logging.debug(f"Response: {response.json()}")
+        assert response.json() == {
+            "focus_sessions": [
+                {
+                    "session_id": str(inserted_id),
+                    "session_status": 0, 
+                    "start_date": "02/22/2025", 
+                    "start_time": "23:16:15", 
+                    "duration": 1, 
+                    "break_duration": 1, 
+                    "session_type": 0, 
+                    "remaining_focus_time": 60, 
+                    "remaining_break_time": 60
+                }
+            ],
+            "status": ResponseStatus.SUCCESS,
+        }
+
+
+    """Test add_focustimer."""
+
+    def setUp(self):
+        """Setup mock database before each test."""
+        self.db = MongoDB().db
+        self.service = FocusTimerService(cfg=None)
+        self.service.db = self.db
+
+        # Clear the collection before each test to prevent interference
+        self.db.get_collection("focus_timer").delete_many({})
+
+    
+    def test_add_focus_timer(self):
+        response = self.service.add_focus_session(
+            user_id="test_user",
+            session_status=SessionStatus.UPCOMING,
+            start_date="02/22/2025",
+            start_time="23:16:15",
+            duration=1,
+            break_duration=1,
+            session_type=SessionType.WORK,
+            remaining_focus_time=60,
+            remaining_break_time=60
+        )
+        assert response[0] != ""  # Should return a valid ObjectId
+        assert response[1] is True  # Should return True
+
+
+    """Test update_focustimer."""
+
+    def test_update_focus_timer(self):
+        collection = self.db.get_collection("focus_timer")
+        # Insert a test entry
+        test_entry = {
+            "user_id": self.user_id,
+            "session_status": SessionStatus.UPCOMING,
+            "start_date": "02/22/2025",
+            "start_time": "23:16:15",
+            "duration": 1,
+            "break_duration": 1,
+            "session_type": SessionType.WORK,
+            "remaining_focus_time": 60,
+            "remaining_break_time": 60
+        }
+        inserted_id = collection.insert_one(test_entry).inserted_id
+
+        # Update the entry without specifying fields to update
+        response = self.app.put(f"/api/v1/focustimer/{str(inserted_id)}", json={}, headers={"x-auth-token": self.jwt_token})
+        assert response.status_code == 400
+
+        # Update the entry with specified fields
+        response = self.app.put(f"/api/v1/focustimer/{str(inserted_id)}", json={"session_type": SessionStatus.ONGOING}, headers={"x-auth-token": self.jwt_token})
+        assert response.status_code == 200
+        assert response.json() == {
+            "user_id": self.user_id,
+            "id": str(inserted_id),
+            "status": ResponseStatus.SUCCESS,
+        }
+
+
+    """Test delete_focustimer."""
+
+    def test_delete_valid_entry(self):
+        """Test deleting an existing session."""
+        collection = self.db.get_collection("focus_timer")
+
+        # Insert a test entry
+        test_entry = {
+            "user_id": self.user_id,
+            "session_status": SessionStatus.UPCOMING,
+            "start_date": "02/22/2025",
+            "start_time": "23:16:15",
+            "duration": 1,
+            "break_duration": 1,
+            "session_type": SessionType.WORK,
+            "remaining_focus_time": 60,
+            "remaining_break_time": 60
+        }
+        inserted_id = collection.insert_one(test_entry).inserted_id
+
+        # Delete the entry
+        response = self.app.delete(f"/api/v1/focustimer/{str(inserted_id)}", headers={"x-auth-token": self.jwt_token})
+        assert response.status_code == 204
+        # Verify the entry is actually removed
+        assert collection.count_documents({"_id": inserted_id}) == 0
+
+    def test_delete_non_existent_entry(self):
+        """Test deleting a non-existent blocklist entry."""
+        response = self.app.delete(f"/api/v1/focustimer/{str(ObjectId())}", headers={"x-auth-token": self.jwt_token}) # Random ObjectId
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

This PR implements the `FocusTimeAPI` and updates the `UserAPI`, the supported operations are:
- `Get` next upcoming focus session
- `Get` all focus sessions of specific status (optional) (@segunfUWaterloo may fetch the completed session for analysis report)
- `Add` focus session
- `Update` focus session
- `Delete` focus session
- `Update` user status (@LokiWager and @liyiran728 may fetch the user status for blocklists)

## Tests
- Added tests for all CRUD operations of focusTimer
- Tested for conflict session addition
