### PR TITLE
Fix convert time to hours

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -92,14 +92,14 @@ class UpdateUserStatusResponse(BaseModel):
 
 
 class AnalyticsListResponse(BaseModel):
-    daily: int = 0
-    weekly: int = 0
+    daily: float = 0
+    weekly: float = 0
     completed_sessions: int = 0
     status: ResponseStatus = ResponseStatus.SUCCESS
 
 
 class AnalyticsWeeklySummaryResponse(BaseModel):
-    duration: int = 0
+    duration: float = 0
     user_id: str
     session_type: SessionType
 

--- a/src/service/analytics.py
+++ b/src/service/analytics.py
@@ -12,6 +12,11 @@ from src.config import Config
 from src.db import MongoDB
 
 
+def _convert_to_hours(time_in_seconds):
+    """converts time from seconds to hours"""
+    return round(time_in_seconds / 3600, 2)
+
+
 class AnalyticsListService(object):
     """class to encapsulate the analytics service."""
 
@@ -30,8 +35,8 @@ class AnalyticsListService(object):
             )
 
         return AnalyticsListResponse(
-            daily=analytics_result["daily"],
-            weekly=analytics_result["weekly"],
+            daily=_convert_to_hours(analytics_result["daily"]),
+            weekly=_convert_to_hours(analytics_result["weekly"]),
             completed_sessions=analytics_result["completed_sessions"],
             status=ResponseStatus.SUCCESS,
         )
@@ -82,7 +87,7 @@ class AnalyticsListService(object):
 
         results = [
             AnalyticsWeeklySummaryResponse(
-                duration=session["duration"],
+                duration=_convert_to_hours(session["duration"]),
                 user_id=session["user_id"]["user_id"],
                 session_type=session["user_id"]["session_type"],
             )

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -60,8 +60,8 @@ class TestAnalytics(unittest.TestCase):
         self.assertDictEqual(
             response.json(),
             {
-                "daily": 120,
-                "weekly": 600,
+                "daily": 0.03,
+                "weekly": 0.17,
                 "completed_sessions": 2,
                 "status": ResponseStatus.SUCCESS,
             },
@@ -123,7 +123,7 @@ class TestAnalytics(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         expected_summary_response = [
             {
-                "duration": 61,
+                "duration": 0.02,
                 "user_id": "focusbuddy_test",
                 "session_type": 0,
             }


### PR DESCRIPTION
## Summary
Adding a fix to convert the time values to hours

When they are presented on the dashboard, the expected scale for the time values is in hours

## Tests
Updated the tests to check for the hour value returned